### PR TITLE
Added missing GA data api to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ gcloud services enable iamcredentials.googleapis.com
 gcloud services enable cloudbuild.googleapis.com
 gcloud services enable googleads.googleapis.com
 gcloud services enable analyticsadmin.googleapis.com
+gcloud services enable analyticsdata.googleapis.com
 
 gcloud app create --region $GAE_LOCATION
 


### PR DESCRIPTION
Added GA data API to install file. Was missing and cause GA4 data to not import. 

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
